### PR TITLE
Adjust asset loading to respect base URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ function App() {
   const [selectedBook, setSelectedBook] = useState<Book | null>(null);
 
   useEffect(() => {
-    fetch('/books.json')
+    fetch(new URL('books.json', import.meta.env.BASE_URL))
       .then(res => res.json())
       .then(data => setBooks(data.books))
       .catch(err => console.error('Error loading books:', err));

--- a/src/components/BookLibrary.tsx
+++ b/src/components/BookLibrary.tsx
@@ -1,5 +1,6 @@
 import { Book } from '../types';
 import { BookOpen } from 'lucide-react';
+import { resolveAssetUrl } from '../utils/assetUrl';
 
 interface BookLibraryProps {
   books: Book[];
@@ -24,7 +25,7 @@ export default function BookLibrary({ books, onSelectBook }: BookLibraryProps) {
             >
               <div className="aspect-[3/4] bg-gray-700 relative overflow-hidden">
                 <img
-                  src={`/${book.thumbnail}`}
+                  src={resolveAssetUrl(book.thumbnail)}
                   alt={book.title}
                   className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
                   onError={(e) => {

--- a/src/components/FlipbookViewer.tsx
+++ b/src/components/FlipbookViewer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Book, BookData } from '../types';
 import { X, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Maximize2, Search, Download, Printer, Home, Grid3x3, SkipBack, SkipForward } from 'lucide-react';
 import HotspotOverlay from './HotspotOverlay';
+import { resolveAssetUrl } from '../utils/assetUrl';
 
 interface FlipbookViewerProps {
   book: Book;
@@ -22,7 +23,7 @@ export default function FlipbookViewer({ book, onClose }: FlipbookViewerProps) {
   const isDragging = useRef<boolean>(false);
 
   useEffect(() => {
-    fetch(`/${book.folder}/pages.json`)
+    fetch(new URL(`${book.folder}/pages.json`, import.meta.env.BASE_URL))
       .then(res => res.json())
       .then(data => {
         setBookData(data);
@@ -31,7 +32,7 @@ export default function FlipbookViewer({ book, onClose }: FlipbookViewerProps) {
           img.onload = () => {
             setImageDimensions({ width: img.width, height: img.height });
           };
-          img.src = `/${book.folder}/${data.pages[0].img}`;
+          img.src = resolveAssetUrl(`${book.folder}/${data.pages[0].img}`);
         }
       })
       .catch(err => console.error('Error loading book data:', err));
@@ -242,7 +243,7 @@ export default function FlipbookViewer({ book, onClose }: FlipbookViewerProps) {
                     }`}
                   >
                     <img
-                      src={`/${book.folder}/${page.img}`}
+                      src={resolveAssetUrl(`${book.folder}/${page.img}`)}
                       alt={`Page ${index + 1}`}
                       className="w-full h-full object-cover"
                     />
@@ -284,7 +285,7 @@ export default function FlipbookViewer({ book, onClose }: FlipbookViewerProps) {
                     }}
                   >
                     <img
-                      src={`/${book.folder}/${leftPage.img}`}
+                      src={resolveAssetUrl(`${book.folder}/${leftPage.img}`)}
                       alt={`Page ${leftPageIndex + 1}`}
                       className="w-full h-full object-cover pointer-events-none"
                       onError={(e) => {
@@ -310,7 +311,7 @@ export default function FlipbookViewer({ book, onClose }: FlipbookViewerProps) {
                   >
                     <div className="w-full h-full" style={{ backfaceVisibility: 'hidden' }}>
                       <img
-                        src={`/${book.folder}/${rightPage.img}`}
+                        src={resolveAssetUrl(`${book.folder}/${rightPage.img}`)}
                         alt={`Page ${rightPageIndex + 1}`}
                         className="w-full h-full object-cover pointer-events-none"
                         onError={(e) => {

--- a/src/components/HotspotOverlay.tsx
+++ b/src/components/HotspotOverlay.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Hotspot } from '../types';
 import { Volume2, Video, ExternalLink, X, Play, Pause } from 'lucide-react';
+import { resolveAssetUrl } from '../utils/assetUrl';
 
 interface HotspotOverlayProps {
   hotspots: Hotspot[];
@@ -130,7 +131,7 @@ export default function HotspotOverlay({ hotspots, bookFolder }: HotspotOverlayP
                 <div className="space-y-4">
                   <audio
                     ref={audioRef}
-                    src={`/${bookFolder}/${activeHotspot.src}`}
+                    src={resolveAssetUrl(`${bookFolder}/${activeHotspot.src}`)}
                     onEnded={() => setIsPlaying(false)}
                     onPlay={() => setIsPlaying(true)}
                     onPause={() => setIsPlaying(false)}
@@ -162,7 +163,7 @@ export default function HotspotOverlay({ hotspots, bookFolder }: HotspotOverlayP
                 <div className="space-y-4">
                   <video
                     ref={videoRef}
-                    src={`/${bookFolder}/${activeHotspot.src}`}
+                    src={resolveAssetUrl(`${bookFolder}/${activeHotspot.src}`)}
                     onEnded={() => setIsPlaying(false)}
                     onPlay={() => setIsPlaying(true)}
                     onPause={() => setIsPlaying(false)}

--- a/src/utils/assetUrl.ts
+++ b/src/utils/assetUrl.ts
@@ -1,0 +1,1 @@
+export const resolveAssetUrl = (path: string) => new URL(path, import.meta.env.BASE_URL).toString();


### PR DESCRIPTION
## Summary
- resolve data fetches and media sources against import.meta.env.BASE_URL
- add a helper to build asset URLs and use it throughout Flipbook components

## Testing
- npm run dev -- --base=/subruta
- npm run build
- npm run preview -- --base=/subruta

------
https://chatgpt.com/codex/tasks/task_e_68e26d0b9f88832ea7916729126842d5