### PR TITLE
Add audio placeholder file and update book references

### DIFF
--- a/public/books/libro-1/audio/archivo.txt
+++ b/public/books/libro-1/audio/archivo.txt
@@ -1,0 +1,1 @@
+Archivo de audio de ejemplo.

--- a/public/books/libro-1/pages.json
+++ b/public/books/libro-1/pages.json
@@ -6,7 +6,7 @@
         {
           "type": "audio",
           "label": "ALH Starter SB Credits",
-          "src": "audio/ALH_Starter_SB_Credits.mp3",
+          "src": "audio/archivo.txt",
           "x": 0.13565708902496468,
           "y": 0.3483967594798829,
           "w": 0.001,
@@ -21,7 +21,7 @@
         {
           "type": "audio",
           "label": "ALH Starter SB Track 0.1",
-          "src": "audio/ALH_Starter_SB_Track_0.1.mp3",
+          "src": "audio/archivo.txt",
           "x": 0.8789124043724723,
           "y": 0.08523384845802982,
           "w": 0.001,
@@ -36,7 +36,7 @@
         {
           "type": "audio",
           "label": "ALH Starter SB Track 0.2",
-          "src": "audio/ALH_Starter_SB_Track_0.2.mp3",
+          "src": "audio/archivo.txt",
           "x": 0.13357805317783877,
           "y": 0.5183198311661787,
           "w": 0.001,
@@ -51,7 +51,7 @@
         {
           "type": "audio",
           "label": "ALH Starter SB Track 0.3",
-          "src": "audio/ALH_Starter_SB_Track_0.3.mp3",
+          "src": "audio/archivo.txt",
           "x": 0.7177871262202153,
           "y": 0.42507999183062156,
           "w": 0.001,
@@ -66,7 +66,7 @@
         {
           "type": "audio",
           "label": "ALH Starter SB Track 0.3",
-          "src": "audio/ALH_Starter_SB_Track_0.3.mp3",
+          "src": "audio/archivo.txt",
           "x": 0.26143875777608133,
           "y": 0.609816869766492,
           "w": 0.5010476391573407,


### PR DESCRIPTION
## Summary
- add a placeholder audio file for libro-1
- update the libro-1 hotspot configuration to point at the new audio path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e26ff782cc832eba26234e199dacdf