### PR TITLE
Add placeholder audio file for libro-1 hotspots

### DIFF
--- a/public/books/libro-1/audio/archivo.txt
+++ b/public/books/libro-1/audio/archivo.txt
@@ -1,0 +1,1 @@
+Audio placeholder for libro-1 hotspots.


### PR DESCRIPTION
## Summary
- add the missing audio placeholder file referenced by libro-1 hotspots

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2783d856c832e9e65e177d3def617