### PR TITLE
Normalize base URLs for asset fetching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,14 @@ import { useState, useEffect } from 'react';
 import BookLibrary from './components/BookLibrary';
 import FlipbookViewer from './components/FlipbookViewer';
 import { Book } from './types';
+import { resolveBaseUrl } from './utils/assetUrl';
 
 function App() {
   const [books, setBooks] = useState<Book[]>([]);
   const [selectedBook, setSelectedBook] = useState<Book | null>(null);
 
   useEffect(() => {
-    fetch(new URL('books.json', import.meta.env.BASE_URL))
+    fetch(new URL('books.json', resolveBaseUrl()))
       .then(res => res.json())
       .then(data => setBooks(data.books))
       .catch(err => console.error('Error loading books:', err));

--- a/src/components/FlipbookViewer.tsx
+++ b/src/components/FlipbookViewer.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Book, BookData } from '../types';
 import { X, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Maximize2, Search, Download, Printer, Home, Grid3x3, SkipBack, SkipForward } from 'lucide-react';
 import HotspotOverlay from './HotspotOverlay';
-import { resolveAssetUrl } from '../utils/assetUrl';
+import { resolveAssetUrl, resolveBaseUrl } from '../utils/assetUrl';
 
 interface FlipbookViewerProps {
   book: Book;
@@ -23,7 +23,7 @@ export default function FlipbookViewer({ book, onClose }: FlipbookViewerProps) {
   const isDragging = useRef<boolean>(false);
 
   useEffect(() => {
-    fetch(new URL(`${book.folder}/pages.json`, import.meta.env.BASE_URL))
+    fetch(new URL(`${book.folder}/pages.json`, resolveBaseUrl()))
       .then(res => res.json())
       .then(data => {
         setBookData(data);

--- a/src/utils/assetUrl.ts
+++ b/src/utils/assetUrl.ts
@@ -1,1 +1,4 @@
-export const resolveAssetUrl = (path: string) => new URL(path, import.meta.env.BASE_URL).toString();
+export const resolveBaseUrl = () =>
+  new URL(import.meta.env.BASE_URL || '/', window.location.origin).toString();
+
+export const resolveAssetUrl = (path: string) => new URL(path, resolveBaseUrl()).toString();


### PR DESCRIPTION
## Summary
- add a resolveBaseUrl utility to normalize asset base URLs
- update App and FlipbookViewer fetches to use the normalized base URL for assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27fca60f4832eaccfcdb977e3497f